### PR TITLE
feat: support exact version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.parallel=true
 org.gradle.configuration-cache=true
 
 group=earth.terrarium
-version=0.8.1
+version=0.8.2

--- a/src/main/kotlin/earth/terrarium/cloche/tasks/GenerateFabricModJson.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/tasks/GenerateFabricModJson.kt
@@ -61,6 +61,14 @@ abstract class GenerateFabricModJson : DefaultTask() {
         }
 
         return buildString {
+            if (range.start == range.end) {
+                require(range.startInclusive.getOrElse(true)) {
+                    "No version in the range"
+                }
+                append(range.start.get())
+                return@buildString
+            }
+
             if (range.start.isPresent) {
                 if (range.startInclusive.getOrElse(true)) {
                     append(">=")
@@ -72,7 +80,7 @@ abstract class GenerateFabricModJson : DefaultTask() {
             }
 
             if (range.end.isPresent) {
-                append(' ')
+                if (range.start.isPresent) append(' ')
 
                 if (range.endExclusive.getOrElse(true)) {
                     append('<')

--- a/src/main/kotlin/earth/terrarium/cloche/tasks/GenerateForgeModsToml.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/tasks/GenerateForgeModsToml.kt
@@ -61,6 +61,14 @@ abstract class GenerateForgeModsToml : DefaultTask() {
                 append(range.start.get())
             }
 
+            if (range.start == range.end) {
+                require(range.startInclusive.getOrElse(true)) {
+                    "No version in the range"
+                }
+                append(']')
+                return@buildString
+            }
+
             append(',')
 
             if (range.end.isPresent) {
@@ -156,7 +164,8 @@ abstract class GenerateForgeModsToml : DefaultTask() {
         }
 
         if (commonMetadata.contributors.get().isNotEmpty()) {
-            mod["credits"] = "Contributors: ${commonMetadata.contributors.get().joinToString(transform = ::convertPerson)}"
+            mod["credits"] =
+                "Contributors: ${commonMetadata.contributors.get().joinToString(transform = ::convertPerson)}"
         }
 
         if (commonMetadata.authors.get().isNotEmpty()) {


### PR DESCRIPTION
- forge isn't allowing identical boundaries `InvalidVersionSpecificationException: Range cannot have identical boundaries: [1.20.1,1.20.1]`

- https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
- https://wiki.fabricmc.net/documentation:fabric_mod_json_spec#versionrange