### PR TITLE
Proper classpath API stub isolation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,15 +21,6 @@ gradlePlugin {
 }
 
 repositories {
-    mavenLocal()
-
-<<<<<<< HEAD
-    maven(url = "https://maven.fabricmc.net/")
-    maven(url = "https://maven.neoforged.net/")
-    maven(url = "https://maven.msrandom.net/repository/cloche/")
-
-=======
->>>>>>> main
     mavenCentral()
 
     maven(url = "https://maven.fabricmc.net/")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,9 @@ gradlePlugin {
 repositories {
     mavenLocal()
 
-    maven(url = "https://maven.msrandom.net/repository/root/")
+    maven(url = "https://maven.fabricmc.net/")
+    maven(url = "https://maven.neoforged.net/")
+    maven(url = "https://maven.msrandom.net/repository/cloche/")
 
     mavenCentral()
     gradlePluginPortal()
@@ -45,7 +47,7 @@ dependencies {
     implementation(group = "net.msrandom", name = "minecraft-codev-includes", version = "0.5.28")
 
     implementation(group = "net.msrandom", name = "class-extensions-gradle-plugin", version = "1.0.10")
-    implementation(group = "net.msrandom", name = "jvm-virtual-source-sets", version = "1.2.3")
+    implementation(group = "net.msrandom", name = "jvm-virtual-source-sets", version = "1.3.0")
     implementation(group = "net.msrandom", name = "classpath-api-stubs", version = "0.1.4")
 
     implementation(group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version = "2.1.0-1.0.29")

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ org.gradle.parallel=true
 org.gradle.configuration-cache=true
 
 group=earth.terrarium
-version=0.9.7
+version=0.9.8

--- a/src/main/kotlin/earth/terrarium/cloche/CommonTargetCreator.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/CommonTargetCreator.kt
@@ -56,7 +56,7 @@ private fun convertClasspath(
 }
 
 fun SourceSet.commonBucketConfigurationName(configurationName: String) =
-    lowerCamelCaseGradleName(name, "common", configurationName)
+    lowerCamelCaseGradleName(name.takeUnless(SourceSet.MAIN_SOURCE_SET_NAME::equals), "common", configurationName)
 
 context(Project)
 internal fun createCommonTarget(

--- a/src/main/kotlin/earth/terrarium/cloche/CompilationVariantCreator.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/CompilationVariantCreator.kt
@@ -48,6 +48,4 @@ internal fun Project.createCompilationVariants(
             }
         }
     }
-
-    compilation.addDependencies()
 }

--- a/src/main/kotlin/earth/terrarium/cloche/Linkage.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/Linkage.kt
@@ -73,10 +73,24 @@ internal fun TargetCompilation.addClasspathDependency(dependency: TargetCompilat
  * Include [dependency] to be compiled alongside the current source, allowing Java platform annotations and Kotlin Multiplatform to function
  */
 context(Project)
-internal fun CompilationInternal.addSourceDependency(dependency: CompilationInternal) {
+internal fun CompilationInternal.addSourceDependency(dependency: CommonCompilation) {
     println("(source dependency) $this -> $dependency")
 
     sourceSet.extension<SourceSetStaticLinkageInfo>().link(dependency.sourceSet)
+
+    project.extend(sourceSet.apiConfigurationName, dependency.sourceSet.commonBucketConfigurationName(dependency.sourceSet.apiConfigurationName))
+    project.extend(sourceSet.compileOnlyApiConfigurationName, dependency.sourceSet.commonBucketConfigurationName(dependency.sourceSet.compileOnlyApiConfigurationName))
+    project.extend(sourceSet.implementationConfigurationName, dependency.sourceSet.commonBucketConfigurationName(dependency.sourceSet.implementationConfigurationName))
+    project.extend(sourceSet.runtimeOnlyConfigurationName, dependency.sourceSet.commonBucketConfigurationName(dependency.sourceSet.runtimeOnlyConfigurationName))
+    project.extend(sourceSet.compileOnlyConfigurationName, dependency.sourceSet.commonBucketConfigurationName(dependency.sourceSet.compileOnlyConfigurationName))
+
+    project.extend(modConfigurationName(sourceSet.implementationConfigurationName), modConfigurationName(dependency.sourceSet.implementationConfigurationName))
+    project.extend(modConfigurationName(sourceSet.apiConfigurationName), modConfigurationName(dependency.sourceSet.apiConfigurationName))
+    project.extend(modConfigurationName(sourceSet.runtimeOnlyConfigurationName), modConfigurationName(dependency.sourceSet.runtimeOnlyConfigurationName))
+    project.extend(modConfigurationName(sourceSet.compileOnlyConfigurationName), modConfigurationName(dependency.sourceSet.compileOnlyConfigurationName))
+    project.extend(modConfigurationName(sourceSet.compileOnlyApiConfigurationName), modConfigurationName(dependency.sourceSet.compileOnlyApiConfigurationName))
+
+    project.extend(sourceSet.mixinsConfigurationName, dependency.sourceSet.mixinsConfigurationName)
 
     project.dependencies.add(sourceSet.annotationProcessorConfigurationName, JAVA_EXPECT_ACTUAL_ANNOTATION_PROCESSOR)
     accessWideners.from(dependency.accessWideners)

--- a/src/main/kotlin/earth/terrarium/cloche/Linkage.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/Linkage.kt
@@ -8,29 +8,64 @@ import net.msrandom.minecraftcodev.core.utils.extension
 import net.msrandom.minecraftcodev.mixins.mixinsConfigurationName
 import net.msrandom.virtualsourcesets.SourceSetStaticLinkageInfo
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSet
 
 const val JAVA_EXPECT_ACTUAL_ANNOTATION_PROCESSOR = "net.msrandom:java-expect-actual-processor:1.0.8"
 const val KOTLIN_MULTIPLATFORM_STUB_SYMBOL_PROCESSOR = "net.msrandom:kmp-actual-stubs-processor:1.0.3"
 
-/**
- * Depend on the compiled output of [dependency], by requesting the capability to allow for resolution to the proper variants
- */
 context(Project)
-private fun SourceSet.addClasspathDependency(dependency: SourceSet) {
-    extend(implementationConfigurationName, dependency.implementationConfigurationName)
-    extend(apiConfigurationName, dependency.apiConfigurationName)
-    extend(runtimeOnlyConfigurationName, dependency.runtimeOnlyConfigurationName)
-    extend(compileOnlyConfigurationName, dependency.compileOnlyConfigurationName)
-    extend(compileOnlyApiConfigurationName, dependency.compileOnlyApiConfigurationName)
+private fun SourceSet.extendConfigurations(dependency: SourceSet, common: Boolean) {
+    val apiBucket: String
+    val compileOnlyApiBucket: String
+    val implementationBucket: String
+    val compileOnlyBucket: String
 
-    extend(modConfigurationName(implementationConfigurationName), modConfigurationName(dependency.implementationConfigurationName))
-    extend(modConfigurationName(apiConfigurationName), modConfigurationName(dependency.apiConfigurationName))
-    extend(modConfigurationName(runtimeOnlyConfigurationName), modConfigurationName(dependency.runtimeOnlyConfigurationName))
-    extend(modConfigurationName(compileOnlyConfigurationName), modConfigurationName(dependency.compileOnlyConfigurationName))
-    extend(modConfigurationName(compileOnlyApiConfigurationName), modConfigurationName(dependency.compileOnlyApiConfigurationName))
+    if (common) {
+        apiBucket = dependency.commonBucketConfigurationName(JavaPlugin.API_CONFIGURATION_NAME)
+        compileOnlyApiBucket = dependency.commonBucketConfigurationName(JavaPlugin.COMPILE_ONLY_API_CONFIGURATION_NAME)
+        implementationBucket = dependency.commonBucketConfigurationName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME)
+        compileOnlyBucket = dependency.commonBucketConfigurationName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME)
+    } else {
+        apiBucket = dependency.apiConfigurationName
+        compileOnlyApiBucket = dependency.compileOnlyApiConfigurationName
+        implementationBucket = dependency.implementationConfigurationName
+        compileOnlyBucket = dependency.compileOnlyConfigurationName
+    }
 
-    extend(mixinsConfigurationName, dependency.mixinsConfigurationName)
+    project.extend(apiConfigurationName, apiBucket)
+    project.extend(compileOnlyApiConfigurationName, compileOnlyApiBucket)
+    project.extend(implementationConfigurationName, implementationBucket)
+    project.extend(compileOnlyConfigurationName, compileOnlyBucket)
+
+    project.extend(runtimeOnlyConfigurationName, dependency.runtimeOnlyConfigurationName)
+
+    project.extend(
+        modConfigurationName(implementationConfigurationName),
+        modConfigurationName(dependency.implementationConfigurationName),
+    )
+
+    project.extend(
+        modConfigurationName(apiConfigurationName),
+        modConfigurationName(dependency.apiConfigurationName),
+    )
+
+    project.extend(
+        modConfigurationName(compileOnlyConfigurationName),
+        modConfigurationName(dependency.compileOnlyConfigurationName),
+    )
+
+    project.extend(
+        modConfigurationName(compileOnlyApiConfigurationName),
+        modConfigurationName(dependency.compileOnlyApiConfigurationName),
+    )
+
+    project.extend(
+        modConfigurationName(runtimeOnlyConfigurationName),
+        modConfigurationName(dependency.runtimeOnlyConfigurationName),
+    )
+
+    project.extend(mixinsConfigurationName, dependency.mixinsConfigurationName)
 }
 
 /**
@@ -46,7 +81,7 @@ internal fun CommonCompilation.addClasspathDependency(dependency: CommonCompilat
         it.add(sourceSet.apiElementsConfigurationName, tasks.named(dependency.sourceSet.jarTaskName))
     }
 
-    sourceSet.addClasspathDependency(dependency.sourceSet)
+    sourceSet.extendConfigurations(dependency.sourceSet, true)
     accessWideners.from(dependency.accessWideners)
 }
 
@@ -65,7 +100,7 @@ internal fun TargetCompilation.addClasspathDependency(dependency: TargetCompilat
         it.add(sourceSet.runtimeElementsConfigurationName, tasks.named(dependency.sourceSet.jarTaskName))
     }
 
-    sourceSet.addClasspathDependency(dependency.sourceSet)
+    sourceSet.extendConfigurations(dependency.sourceSet, false)
     accessWideners.from(dependency.accessWideners)
 }
 
@@ -78,19 +113,7 @@ internal fun CompilationInternal.addSourceDependency(dependency: CommonCompilati
 
     sourceSet.extension<SourceSetStaticLinkageInfo>().link(dependency.sourceSet)
 
-    project.extend(sourceSet.apiConfigurationName, dependency.sourceSet.commonBucketConfigurationName(dependency.sourceSet.apiConfigurationName))
-    project.extend(sourceSet.compileOnlyApiConfigurationName, dependency.sourceSet.commonBucketConfigurationName(dependency.sourceSet.compileOnlyApiConfigurationName))
-    project.extend(sourceSet.implementationConfigurationName, dependency.sourceSet.commonBucketConfigurationName(dependency.sourceSet.implementationConfigurationName))
-    project.extend(sourceSet.runtimeOnlyConfigurationName, dependency.sourceSet.commonBucketConfigurationName(dependency.sourceSet.runtimeOnlyConfigurationName))
-    project.extend(sourceSet.compileOnlyConfigurationName, dependency.sourceSet.commonBucketConfigurationName(dependency.sourceSet.compileOnlyConfigurationName))
-
-    project.extend(modConfigurationName(sourceSet.implementationConfigurationName), modConfigurationName(dependency.sourceSet.implementationConfigurationName))
-    project.extend(modConfigurationName(sourceSet.apiConfigurationName), modConfigurationName(dependency.sourceSet.apiConfigurationName))
-    project.extend(modConfigurationName(sourceSet.runtimeOnlyConfigurationName), modConfigurationName(dependency.sourceSet.runtimeOnlyConfigurationName))
-    project.extend(modConfigurationName(sourceSet.compileOnlyConfigurationName), modConfigurationName(dependency.sourceSet.compileOnlyConfigurationName))
-    project.extend(modConfigurationName(sourceSet.compileOnlyApiConfigurationName), modConfigurationName(dependency.sourceSet.compileOnlyApiConfigurationName))
-
-    project.extend(sourceSet.mixinsConfigurationName, dependency.sourceSet.mixinsConfigurationName)
+    sourceSet.extendConfigurations(dependency.sourceSet, true)
 
     project.dependencies.add(sourceSet.annotationProcessorConfigurationName, JAVA_EXPECT_ACTUAL_ANNOTATION_PROCESSOR)
     accessWideners.from(dependency.accessWideners)

--- a/src/main/kotlin/earth/terrarium/cloche/ProjectPluginApplicator.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/ProjectPluginApplicator.kt
@@ -25,37 +25,37 @@ import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.api.tasks.SourceSetContainer
 
-fun applyToProject(target: Project) {
-    val cloche = target.extensions.create("cloche", ClocheExtension::class.java)
+fun applyToProject(project: Project) {
+    val cloche = project.extensions.create("cloche", ClocheExtension::class.java)
 
-    target.plugins.apply(MinecraftCodevFabricPlugin::class.java)
-    target.plugins.apply(MinecraftCodevForgePlugin::class.java)
-    target.plugins.apply(MinecraftCodevRemapperPlugin::class.java)
-    target.plugins.apply(MinecraftCodevIncludesPlugin::class.java)
-    target.plugins.apply(MinecraftCodevDecompilerPlugin::class.java)
-    target.plugins.apply(MinecraftCodevAccessWidenerPlugin::class.java)
-    target.plugins.apply(MinecraftCodevMixinsPlugin::class.java)
-    target.plugins.apply(MinecraftCodevRunsPlugin::class.java)
+    project.plugins.apply(MinecraftCodevFabricPlugin::class.java)
+    project.plugins.apply(MinecraftCodevForgePlugin::class.java)
+    project.plugins.apply(MinecraftCodevRemapperPlugin::class.java)
+    project.plugins.apply(MinecraftCodevIncludesPlugin::class.java)
+    project.plugins.apply(MinecraftCodevDecompilerPlugin::class.java)
+    project.plugins.apply(MinecraftCodevAccessWidenerPlugin::class.java)
+    project.plugins.apply(MinecraftCodevMixinsPlugin::class.java)
+    project.plugins.apply(MinecraftCodevRunsPlugin::class.java)
 
-    target.plugins.apply(JavaVirtualSourceSetsPlugin::class.java)
-    target.plugins.apply(ClassExtensionsPlugin::class.java)
+    project.plugins.apply(JavaVirtualSourceSetsPlugin::class.java)
+    project.plugins.apply(ClassExtensionsPlugin::class.java)
 
-    target.plugins.apply(JavaLibraryPlugin::class.java)
+    project.plugins.apply(JavaLibraryPlugin::class.java)
 
-    target.plugins.withId(KOTLIN_JVM_PLUGIN_ID) {
-        target.plugins.apply(KspGradleSubplugin::class.java)
+    project.plugins.withId(KOTLIN_JVM_PLUGIN_ID) {
+        project.plugins.apply(KspGradleSubplugin::class.java)
     }
 
-    ClocheRepositoriesExtension.register(target.repositories)
+    ClocheRepositoriesExtension.register(project.repositories)
 
-    target.dependencies.attributesSchema { schema ->
+    project.dependencies.attributesSchema { schema ->
         schema.attribute(SIDE_ATTRIBUTE) {
             it.compatibilityRules.add(VariantCompatibilityRule::class.java)
             it.disambiguationRules.add(VariantDisambiguationRule::class.java)
         }
     }
 
-    target.dependencies.artifactTypes {
+    project.dependencies.artifactTypes {
         it.named(ArtifactTypeDefinition.JAR_TYPE) { jar ->
             jar.attributes.attribute(
                 ModTransformationStateAttribute.ATTRIBUTE,
@@ -64,39 +64,27 @@ fun applyToProject(target: Project) {
         }
     }
 
-    target.extension<SourceSetContainer>().all {
-        it.extension<SourceSetStaticLinkageInfo>().links.all { dependency ->
-            target.extend(modConfigurationName(it.implementationConfigurationName), modConfigurationName(dependency.implementationConfigurationName))
-            target.extend(modConfigurationName(it.apiConfigurationName), modConfigurationName(dependency.apiConfigurationName))
-            target.extend(modConfigurationName(it.runtimeOnlyConfigurationName), modConfigurationName(dependency.runtimeOnlyConfigurationName))
-            target.extend(modConfigurationName(it.compileOnlyConfigurationName), modConfigurationName(dependency.compileOnlyConfigurationName))
-            target.extend(modConfigurationName(it.compileOnlyApiConfigurationName), modConfigurationName(dependency.compileOnlyApiConfigurationName))
+    project.ideaSyncHook()
 
-            target.extend(it.mixinsConfigurationName, dependency.mixinsConfigurationName)
-        }
-    }
-
-    target.ideaSyncHook()
-
-    target.dependencies.components.withModule(
+    project.dependencies.components.withModule(
         "net.minecraftforge:forge",
         ForgeLexToNeoComponentMetadataRule::class.java
     ) {
         it.params(
-            getGlobalCacheDirectory(target),
+            getGlobalCacheDirectory(project),
             VERSION_MANIFEST_URL,
-            target.gradle.startParameter.isOffline,
+            project.gradle.startParameter.isOffline,
         )
     }
 
-    target.dependencies.components.withModule(
+    project.dependencies.components.withModule(
         "de.oceanlabs.mcp:mcp_config",
         McpConfigToNeoformComponentMetadataRule::class.java
     ) {
         it.params(
-            getGlobalCacheDirectory(target),
+            getGlobalCacheDirectory(project),
         )
     }
 
-    applyTargets(target, cloche)
+    applyTargets(project, cloche)
 }

--- a/src/main/kotlin/earth/terrarium/cloche/TargetApplicator.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/TargetApplicator.kt
@@ -1,5 +1,6 @@
 package earth.terrarium.cloche
 
+import earth.terrarium.cloche.target.CommonCompilation
 import earth.terrarium.cloche.target.CommonTargetInternal
 import earth.terrarium.cloche.target.CommonTopLevelCompilation
 import earth.terrarium.cloche.target.CompilationInternal
@@ -40,7 +41,7 @@ internal fun applyTargets(project: Project, cloche: ClocheExtension) {
                 return common.client()
             }
 
-            fun setDependenciesWithData(common: CommonTargetInternal): CompilationInternal {
+            fun setDependenciesWithData(common: CommonTargetInternal): CommonCompilation {
                 common.dependsOn.all {
                     setDependenciesWithData(it as CommonTargetInternal)
                 }
@@ -48,7 +49,7 @@ internal fun applyTargets(project: Project, cloche: ClocheExtension) {
                 return common.data()
             }
 
-            fun setDependenciesWithTest(common: CommonTargetInternal): CompilationInternal {
+            fun setDependenciesWithTest(common: CommonTargetInternal): CommonCompilation {
                 common.dependsOn.all {
                     setDependenciesWithTest(it as CommonTargetInternal)
                 }
@@ -146,7 +147,7 @@ internal fun applyTargets(project: Project, cloche: ClocheExtension) {
             dependency as CommonTargetInternal
 
             with(project) {
-                fun add(compilation: CompilationInternal, dependencyCompilation: CompilationInternal) {
+                fun add(compilation: CompilationInternal, dependencyCompilation: CommonCompilation) {
                     compilation.addSourceDependency(dependencyCompilation)
                 }
 

--- a/src/main/kotlin/earth/terrarium/cloche/target/CompilationInternal.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/target/CompilationInternal.kt
@@ -69,7 +69,7 @@ internal abstract class CompilationInternal : Compilation {
         get() = name.replace(TARGET_NAME_PATH_SEPARATOR, '/')
 
     val collapsedName
-        get() = name.takeUnless { it == SourceSet.MAIN_SOURCE_SET_NAME }
+        get() = name.takeUnless(SourceSet.MAIN_SOURCE_SET_NAME::equals)
 
     override fun withJavadocJar() {
         withJavadoc = true

--- a/src/main/kotlin/earth/terrarium/cloche/target/CompilationInternal.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/target/CompilationInternal.kt
@@ -92,67 +92,6 @@ internal abstract class CompilationInternal : Compilation {
         }
     }
 
-    fun addDependencies() {
-        val modImplementation =
-            project.configurations.dependencyScope(modConfigurationName(sourceSet.implementationConfigurationName)) {
-                it.addCollectedDependencies(dependencyHandler.modImplementation)
-            }.get()
-
-        val modRuntimeOnly =
-            project.configurations.dependencyScope(modConfigurationName(sourceSet.runtimeOnlyConfigurationName)) {
-                it.addCollectedDependencies(dependencyHandler.modRuntimeOnly)
-            }.get()
-
-        val modCompileOnly =
-            project.configurations.dependencyScope(modConfigurationName(sourceSet.compileOnlyConfigurationName)) {
-                it.addCollectedDependencies(dependencyHandler.modCompileOnly)
-            }.get()
-
-        val modApi =
-            project.configurations.dependencyScope(modConfigurationName(sourceSet.apiConfigurationName)) {
-                it.addCollectedDependencies(dependencyHandler.modApi)
-            }.get()
-
-        val modCompileOnlyApi =
-            project.configurations.dependencyScope(modConfigurationName(sourceSet.compileOnlyApiConfigurationName)) {
-                it.addCollectedDependencies(dependencyHandler.modCompileOnlyApi)
-            }.get()
-
-        project.configurations.named(sourceSet.implementationConfigurationName) {
-            it.extendsFrom(modImplementation)
-
-            it.addCollectedDependencies(dependencyHandler.implementation)
-        }
-
-        project.configurations.named(sourceSet.compileOnlyConfigurationName) {
-            it.extendsFrom(modCompileOnly)
-
-            it.addCollectedDependencies(dependencyHandler.compileOnly)
-        }
-
-        project.configurations.named(sourceSet.runtimeOnlyConfigurationName) {
-            it.extendsFrom(modRuntimeOnly)
-
-            it.addCollectedDependencies(dependencyHandler.runtimeOnly)
-        }
-
-        project.configurations.named(sourceSet.apiConfigurationName) {
-            it.extendsFrom(modApi)
-
-            it.addCollectedDependencies(dependencyHandler.api)
-        }
-
-        project.configurations.named(sourceSet.compileOnlyApiConfigurationName) {
-            it.extendsFrom(modCompileOnlyApi)
-
-            it.addCollectedDependencies(dependencyHandler.compileOnlyApi)
-        }
-
-        project.configurations.named(sourceSet.annotationProcessorConfigurationName) {
-            it.addCollectedDependencies(dependencyHandler.annotationProcessor)
-        }
-    }
-
     override fun toString() = target.name + TARGET_NAME_PATH_SEPARATOR + name
 }
 

--- a/src/main/kotlin/earth/terrarium/cloche/target/CompilationInternal.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/target/CompilationInternal.kt
@@ -13,7 +13,9 @@ import org.gradle.api.Buildable
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ArtifactView
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.ResolvableConfiguration
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.file.SourceDirectorySet
@@ -26,7 +28,7 @@ import javax.inject.Inject
 internal fun modConfigurationName(name: String) =
     lowerCamelCaseGradleName("mod", name)
 
-internal fun getNonProjectArtifacts(configurationContainer: ConfigurationContainer, configurationName: String): Provider<ArtifactView> = configurationContainer.named(configurationName).map {
+internal fun getNonProjectArtifacts(configuration: Provider<out Configuration>): Provider<ArtifactView> = configuration.map {
     it.incoming.artifactView {
         it.componentFilter {
             // We do *not* want to build anything during sync.
@@ -37,7 +39,7 @@ internal fun getNonProjectArtifacts(configurationContainer: ConfigurationContain
 
 context(Project)
 internal fun getRelevantSyncArtifacts(configurationName: String): Provider<Buildable> =
-    getNonProjectArtifacts(configurations, configurationName).map { it.files }
+    getNonProjectArtifacts(configurations.named(configurationName)).map { it.files }
 
 @Suppress("UnstableApiUsage")
 @JvmDefaultWithoutCompatibility

--- a/src/main/kotlin/earth/terrarium/cloche/target/TargetCompilation.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/target/TargetCompilation.kt
@@ -64,7 +64,7 @@ internal fun registerCompilationTransformations(
     namedMinecraftFile: Provider<RegularFile>,
     extraClasspathFiles: Provider<List<RegularFile>>,
 ): Pair<TaskProvider<AccessWiden>, Provider<RegularFile>> {
-    val collapsedName = compilationName.takeUnless { it == SourceSet.MAIN_SOURCE_SET_NAME }
+    val collapsedName = compilationName.takeUnless(SourceSet.MAIN_SOURCE_SET_NAME::equals)
 
     val project = target.project
 

--- a/src/main/kotlin/earth/terrarium/cloche/target/fabric/FabricTargetImpl.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/target/fabric/FabricTargetImpl.kt
@@ -305,7 +305,7 @@ internal abstract class FabricTargetImpl @Inject constructor(name: String) :
 
         val commonTask = registerCompilationTransformations(
             this,
-            lowerCamelCaseGradleName(name.takeUnless { it == SourceSet.MAIN_SOURCE_SET_NAME }, "common"),
+            lowerCamelCaseGradleName(name.takeUnless(SourceSet.MAIN_SOURCE_SET_NAME::equals), "common"),
             compilationSourceSet(this, name, isSingleTarget),
             remapCommon.flatMap(RemapTask::outputFile),
             project.provider { emptyList() },


### PR DESCRIPTION
The common classpath should not include anything other than the stubs by default. This achieves that