### PR TITLE
fix: access widen task using mod files instead of full runtime classpath

### DIFF
--- a/src/main/kotlin/earth/terrarium/cloche/TargetHandler.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/TargetHandler.kt
@@ -1,7 +1,14 @@
 package earth.terrarium.cloche
 
-import earth.terrarium.cloche.target.*
+import earth.terrarium.cloche.target.MinecraftTargetInternal
+import earth.terrarium.cloche.target.TargetCompilation
+import earth.terrarium.cloche.target.addCollectedDependencies
+import earth.terrarium.cloche.target.configureSourceSet
 import earth.terrarium.cloche.target.fabric.FabricTargetImpl
+import earth.terrarium.cloche.target.localImplementationConfigurationName
+import earth.terrarium.cloche.target.localRuntimeConfigurationName
+import earth.terrarium.cloche.target.modConfigurationName
+import earth.terrarium.cloche.target.sourceSetName
 import net.msrandom.minecraftcodev.core.MinecraftOperatingSystemAttribute
 import net.msrandom.minecraftcodev.core.VERSION_MANIFEST_URL
 import net.msrandom.minecraftcodev.core.getVersionList

--- a/src/main/kotlin/earth/terrarium/cloche/TargetHandler.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/TargetHandler.kt
@@ -1,14 +1,7 @@
 package earth.terrarium.cloche
 
-import earth.terrarium.cloche.target.MinecraftTargetInternal
-import earth.terrarium.cloche.target.TargetCompilation
-import earth.terrarium.cloche.target.addCollectedDependencies
-import earth.terrarium.cloche.target.configureSourceSet
+import earth.terrarium.cloche.target.*
 import earth.terrarium.cloche.target.fabric.FabricTargetImpl
-import earth.terrarium.cloche.target.localImplementationConfigurationName
-import earth.terrarium.cloche.target.localRuntimeConfigurationName
-import earth.terrarium.cloche.target.modConfigurationName
-import earth.terrarium.cloche.target.sourceSetName
 import net.msrandom.minecraftcodev.core.MinecraftOperatingSystemAttribute
 import net.msrandom.minecraftcodev.core.VERSION_MANIFEST_URL
 import net.msrandom.minecraftcodev.core.getVersionList
@@ -102,6 +95,8 @@ private fun TargetCompilation.addDependencies() {
     }
 
     project.configurations.resolvable(modConfigurationName(sourceSet.compileClasspathConfigurationName)) {
+        it.isTransitive = false
+
         it.shouldResolveConsistentlyWith(project.configurations.getByName(sourceSet.compileClasspathConfigurationName))
 
         it.extendsFrom(project.configurations.getByName(modConfigurationName(sourceSet.compileOnlyConfigurationName)))
@@ -115,6 +110,8 @@ private fun TargetCompilation.addDependencies() {
     }
 
     project.configurations.resolvable(modConfigurationName(sourceSet.runtimeClasspathConfigurationName)) {
+        it.isTransitive = false
+
         it.shouldResolveConsistentlyWith(project.configurations.getByName(sourceSet.runtimeClasspathConfigurationName))
 
         it.extendsFrom(project.configurations.getByName(modConfigurationName(sourceSet.runtimeOnlyConfigurationName)))

--- a/src/main/kotlin/earth/terrarium/cloche/TargetHandler.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/TargetHandler.kt
@@ -1,14 +1,7 @@
 package earth.terrarium.cloche
 
-import earth.terrarium.cloche.target.MinecraftTargetInternal
-import earth.terrarium.cloche.target.TargetCompilation
-import earth.terrarium.cloche.target.addCollectedDependencies
-import earth.terrarium.cloche.target.configureSourceSet
+import earth.terrarium.cloche.target.*
 import earth.terrarium.cloche.target.fabric.FabricTargetImpl
-import earth.terrarium.cloche.target.localImplementationConfigurationName
-import earth.terrarium.cloche.target.localRuntimeConfigurationName
-import earth.terrarium.cloche.target.modConfigurationName
-import earth.terrarium.cloche.target.sourceSetName
 import net.msrandom.minecraftcodev.core.MinecraftOperatingSystemAttribute
 import net.msrandom.minecraftcodev.core.VERSION_MANIFEST_URL
 import net.msrandom.minecraftcodev.core.getVersionList
@@ -102,8 +95,6 @@ private fun TargetCompilation.addDependencies() {
     }
 
     project.configurations.resolvable(modConfigurationName(sourceSet.compileClasspathConfigurationName)) {
-        it.isTransitive = false
-
         it.shouldResolveConsistentlyWith(project.configurations.getByName(sourceSet.compileClasspathConfigurationName))
 
         it.extendsFrom(project.configurations.getByName(modConfigurationName(sourceSet.compileOnlyConfigurationName)))
@@ -117,8 +108,6 @@ private fun TargetCompilation.addDependencies() {
     }
 
     project.configurations.resolvable(modConfigurationName(sourceSet.runtimeClasspathConfigurationName)) {
-        it.isTransitive = false
-
         it.shouldResolveConsistentlyWith(project.configurations.getByName(sourceSet.runtimeClasspathConfigurationName))
 
         it.extendsFrom(project.configurations.getByName(modConfigurationName(sourceSet.runtimeOnlyConfigurationName)))

--- a/src/main/kotlin/earth/terrarium/cloche/target/TargetCompilation.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/target/TargetCompilation.kt
@@ -1,6 +1,11 @@
 package earth.terrarium.cloche.target
 
-import earth.terrarium.cloche.*
+import earth.terrarium.cloche.ClocheExtension
+import earth.terrarium.cloche.DATA_ATTRIBUTE
+import earth.terrarium.cloche.IncludeTransformationState
+import earth.terrarium.cloche.ModTransformationStateAttribute
+import earth.terrarium.cloche.PublicationSide
+import earth.terrarium.cloche.SIDE_ATTRIBUTE
 import net.msrandom.minecraftcodev.accesswidener.AccessWiden
 import net.msrandom.minecraftcodev.core.utils.extension
 import net.msrandom.minecraftcodev.core.utils.getGlobalCacheDirectory
@@ -43,8 +48,7 @@ internal fun Project.getModFiles(
     return project.files(classpath.zip(modDependencies) { classpath, modDependencies ->
         val resolutionResult = modDependencies.incoming.resolutionResult
 
-        val componentIdentifiers =
-            resolutionResult.allComponents.map(ResolvedComponentResult::getId) - resolutionResult.root.id
+        val componentIdentifiers = resolutionResult.allComponents.map(ResolvedComponentResult::getId) - resolutionResult.root.id
 
         val filteredIdentifiers = componentIdentifiers.filter { it !is ProjectComponentIdentifier }
 


### PR DESCRIPTION
Reverts the previous change that made the configurations non transitive, because it caused problems with the way fabric api is structured and accesswideners are propegated. Also added back a variation of the filter in `getModFiles` method to still only provide non transitive elements by default.