### PR TITLE
fix(Metadata): Fix modproperties on both Forge & NeoForge

### DIFF
--- a/src/main/kotlin/earth/terrarium/cloche/tasks/GenerateForgeModsToml.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/tasks/GenerateForgeModsToml.kt
@@ -157,10 +157,6 @@ abstract class GenerateForgeModsToml : DefaultTask() {
             "Contributors: ${it.joinToString(transform = ::convertPerson)}"
         }
 
-        val modProperties = (metadata.custom.get() + metadata.modProperties.get()).mapValues { (_, value) ->
-            convertToTomlFromSerializable(value)
-        }
-
         val mod = ForgeMod(
             modId = modId,
             version = modVersion.get(),
@@ -170,7 +166,6 @@ abstract class GenerateForgeModsToml : DefaultTask() {
             displayURL = metadata.url.orNull,
             credits = credits,
             authors = authors,
-            modproperties = modProperties,
         )
 
         if (neoforge.get()) {
@@ -185,6 +180,10 @@ abstract class GenerateForgeModsToml : DefaultTask() {
                 )
             }
 
+            val modProperties = (metadata.custom.get() + metadata.modProperties.get()).mapValues { (_, value) ->
+                convertToTomlFromSerializable(value)
+            }.map { mapOf(it.toPair()) }
+
             val mods = NeoForgeMods(
                 modLoader = metadata.modLoader.get(),
                 loaderVersion = loaderVersionRange,
@@ -196,6 +195,7 @@ abstract class GenerateForgeModsToml : DefaultTask() {
                 mods = listOf(mod),
                 dependencies = mapOf(modId to dependencies),
                 logoBlur = metadata.blurLogo.orNull,
+                modproperties = mapOf(modId to modProperties)
             )
 
             output.outputStream().use {
@@ -212,6 +212,10 @@ abstract class GenerateForgeModsToml : DefaultTask() {
                 )
             }
 
+            val modProperties = (metadata.custom.get() + metadata.modProperties.get()).mapValues { (_, value) ->
+                convertToTomlFromSerializable(value)
+            }
+
             val mods = ForgeMods(
                 modLoader = metadata.modLoader.get(),
                 loaderVersion = loaderVersionRange,
@@ -220,6 +224,7 @@ abstract class GenerateForgeModsToml : DefaultTask() {
                 mods = listOf(mod),
                 dependencies = mapOf(modId to dependencies),
                 logoBlur = metadata.blurLogo.orNull,
+                modproperties = mapOf(modId to modProperties)
             )
 
             output.outputStream().use {

--- a/src/main/kotlin/earth/terrarium/cloche/tasks/GenerateForgeModsToml.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/tasks/GenerateForgeModsToml.kt
@@ -157,6 +157,10 @@ abstract class GenerateForgeModsToml : DefaultTask() {
             "Contributors: ${it.joinToString(transform = ::convertPerson)}"
         }
 
+        val modProperties = (metadata.custom.get() + metadata.modProperties.get()).mapValues { (_, value) ->
+            convertToTomlFromSerializable(value)
+        }
+
         val mod = ForgeMod(
             modId = modId,
             version = modVersion.get(),
@@ -179,10 +183,6 @@ abstract class GenerateForgeModsToml : DefaultTask() {
                     side = it.environment.getOrElse(CommonMetadata.Environment.Both),
                 )
             }
-
-            val modProperties = (metadata.custom.get() + metadata.modProperties.get()).mapValues { (_, value) ->
-                convertToTomlFromSerializable(value)
-            }.map { mapOf(it.toPair()) }
 
             val mods = NeoForgeMods(
                 modLoader = metadata.modLoader.get(),
@@ -210,10 +210,6 @@ abstract class GenerateForgeModsToml : DefaultTask() {
                     ordering = it.ordering.getOrElse(CommonMetadata.Dependency.Ordering.None),
                     side = it.environment.getOrElse(CommonMetadata.Environment.Both),
                 )
-            }
-
-            val modProperties = (metadata.custom.get() + metadata.modProperties.get()).mapValues { (_, value) ->
-                convertToTomlFromSerializable(value)
             }
 
             val mods = ForgeMods(

--- a/src/main/kotlin/earth/terrarium/cloche/tasks/data/ForgeMods.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/tasks/data/ForgeMods.kt
@@ -26,6 +26,7 @@ data class ForgeMods(
     val issueTrackerURL: String? = null,
     val mods: List<ForgeMod>,
     val logoBlur: Boolean? = null,
+    val modproperties: Map<String, Map<String, TomlElement>> = emptyMap()
 ) {
     @Serializable
     data class Dependency(
@@ -59,8 +60,7 @@ data class ForgeMod(
     val logoFile: String? = null,
     val displayURL: String? = null,
     val credits: String? = null,
-    val authors: String? = null,
-    val modproperties: Map<String, TomlElement> = emptyMap(),
+    val authors: String? = null
 )
 
 inline fun <reified T> Toml.decodeFromStream(stream: InputStream) =

--- a/src/main/kotlin/earth/terrarium/cloche/tasks/data/NeoForgeMods.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/tasks/data/NeoForgeMods.kt
@@ -16,7 +16,7 @@ data class NeoForgeMods(
     val issueTrackerURL: String? = null,
     val mods: List<ForgeMod>,
     val logoBlur: Boolean? = null,
-    val modproperties: Map<String, List<Map<String, TomlElement>>> = emptyMap()
+    val modproperties: Map<String, Map<String, TomlElement>> = emptyMap()
 ) {
     @Serializable
     data class AccessTransformer(

--- a/src/main/kotlin/earth/terrarium/cloche/tasks/data/NeoForgeMods.kt
+++ b/src/main/kotlin/earth/terrarium/cloche/tasks/data/NeoForgeMods.kt
@@ -3,6 +3,7 @@ package earth.terrarium.cloche.tasks.data
 import earth.terrarium.cloche.api.metadata.CommonMetadata
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import net.peanuuutz.tomlkt.TomlElement
 
 @Serializable
 data class NeoForgeMods(
@@ -15,6 +16,7 @@ data class NeoForgeMods(
     val issueTrackerURL: String? = null,
     val mods: List<ForgeMod>,
     val logoBlur: Boolean? = null,
+    val modproperties: Map<String, List<Map<String, TomlElement>>> = emptyMap()
 ) {
     @Serializable
     data class AccessTransformer(


### PR DESCRIPTION
Moved mod properties out of the `ForgeMod` class as they behave much closer to the likes of `dependencies`, fixing the name of the table/array of tables being wrong. This separation also allows us to specify per platform modproperties as Forge expects a table and NeoForge expects an array of tables.

In my testing this did generate an empty `modproperties` table/array of tables above the actual tables, but not only would this presumably not interfere with functionality but also because of how similar one of these 2 blocks is to the `dependencies` field, I doubt it would actually do so in production.

This would fix #154